### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * *"
 jobs:
   rebase:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/rebase@v3


### PR DESCRIPTION
Potential fix for [https://github.com/flcdrg/Verify.Cli/security/code-scanning/3](https://github.com/flcdrg/Verify.Cli/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block to the workflow. Since the action `peter-evans/rebase@v3` is used to perform rebases, it likely requires `contents: read` to access code contents and `pull-requests: write` to update pull requests. The `permissions` block should be added either at the root level of the workflow (to apply to all jobs) or inside the `rebase` job (if only that job needs these permissions). Here, we'll apply it specifically to the `rebase` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
