### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -176,6 +176,8 @@ jobs:
     name: Update release draft
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
 
     if: github.ref == 'refs/heads/main' # Running this job only for main branch
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/flcdrg/Verify.Cli/security/code-scanning/5](https://github.com/flcdrg/Verify.Cli/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `update_release_draft` job, specifying the least privileges required. Since this job interacts with release drafts and uploads artifacts, it likely requires `contents: read` and `contents: write` permissions. 

We will modify the `.github/workflows/dotnet.yml` file to include an explicit `permissions` block under the `update_release_draft` job. This will ensure the workflow adheres to the principle of least privilege by limiting the `GITHUB_TOKEN` permissions to only what is necessary for this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
