### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -142,6 +142,8 @@ jobs:
     name: Test images
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/flcdrg/Verify.Cli/security/code-scanning/4](https://github.com/flcdrg/Verify.Cli/security/code-scanning/4)

The issue can be fixed by adding a `permissions` block to the `test_images` job, restricting the permissions of the `GITHUB_TOKEN` to only the minimal set required for the job. Since the job is primarily performing read operations (downloading artifacts and interacting with Docker), the `contents: read` permission is sufficient.

The changes will be made to the `.github/workflows/dotnet.yml` file under the `test_images` job configuration. Specifically:
- Add a `permissions` block with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
