### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,6 +38,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json


### PR DESCRIPTION
Potential fix for [https://github.com/flcdrg/Verify.Cli/security/code-scanning/2](https://github.com/flcdrg/Verify.Cli/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `build` job so that it only grants the minimum required privileges. For most build jobs, `contents: read` is sufficient, as it allows the job to read repository contents (needed for actions like `actions/checkout` and downloading dependencies), but not to write to the repository or make changes. This change should be made directly under the `build:` job declaration, on the same indentation level as `runs-on`. No new imports, methods, or definitions are required; only the addition of the `permissions` block in the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
