### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   dump:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Dump GitHub context
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/flcdrg/Verify.Cli/security/code-scanning/1](https://github.com/flcdrg/Verify.Cli/security/code-scanning/1)

To resolve the issue, we need to define a `permissions` block for the `dump` job in the workflow. Since the `dump` job only echoes the GitHub context and does not require elevated permissions, we can set the permissions to `contents: read`. This adheres to the principle of least privilege while ensuring the job has access to the information it needs.

Changes are localized to the `.github/workflows/publish.yml` file. No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
