### PR TITLE
Enhance scrubbing options for multiple patterns and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The first time you use Verify.Cli, it will output the contents of the file.
 - `--file` or `-f`: The file to verify (required)
 - `--verified-dir` or `-d`: Directory to store/look for .verified files (optional)
 - `--scrub-inline-datetime`: Format for inline date times to scrub, e.g., 'yyyy-MM-ddTHH:mm:ss.fffZ' (optional)
-- `--scrub-inline-pattern`: Regex pattern to match inline strings for scrubbing, e.g., '"/astro/[^"]+"|(?&lt;prefix&gt;")/_astro/[^"]+(?&lt;suffix&gt;")' (optional)
-- `--scrub-inline-remove`: Text to match and remove from the file content, e.g., 'temp-id-123' (optional)
+- `--scrub-inline-pattern`: One or more regex patterns to match inline strings for scrubbing. Repeat the option to specify multiple patterns. For example: '"/astro/[^"]+"' or '(?&lt;prefix&gt;")/_astro/[^"]+(?&lt;suffix&gt;")' (optional)
+- `--scrub-inline-remove`: One or more text values to remove from the file content (exact match, not regex). Repeat the option to specify multiple values, e.g., 'temp-id-123' (optional)
 - `--verbosity`: Set the verbosity level. Options are: quiet, minimal, normal, detailed, diagnostic (optional, default: normal)
 
 ### Examples
@@ -85,6 +85,14 @@ verify --file C:\tmp\output.html --scrub-inline-pattern "\"/astro/[^\"]+\""
 
 This will scrub inline strings matching the regex pattern (e.g., dynamic asset paths like "/astro/chunk-123.js") from the file content before verification.
 
+With multiple pattern scrubbers (repeat the option):
+
+```pwsh
+verify --file C:\tmp\output.html --scrub-inline-pattern "\"/astro/[^\"]+\"" --scrub-inline-pattern "(?<prefix>\")/_astro/[^\"]+(?<suffix>\")"
+```
+
+This applies both patterns in order.
+
 With pattern scrubbing using named groups to preserve parts:
 
 ```pwsh
@@ -100,6 +108,14 @@ verify --file C:\tmp\output.html --scrub-inline-remove "data-temp-id"
 ```
 
 This will remove all instances of the text "data-temp-id" from the file content before verification.
+
+With multiple text removals (repeat the option):
+
+```pwsh
+verify --file C:\tmp\output.html --scrub-inline-remove "data-temp-id" --scrub-inline-remove "temp-session"
+```
+
+This removes both values.
 
 With verbosity control:
 
@@ -118,7 +134,7 @@ This will run with minimal output (quiet mode). Available verbosity levels are:
 You can combine options:
 
 ```pwsh
-verify --file C:\tmp\log.txt --verified-dir C:\MyVerifiedFiles --scrub-inline-datetime "yyyy-MM-dd HH:mm:ss" --scrub-inline-pattern "id=\"[^\"]+\"" --scrub-inline-remove "temp-session" --verbosity detailed
+verify --file C:\tmp\log.txt --verified-dir C:\MyVerifiedFiles --scrub-inline-datetime "yyyy-MM-dd HH:mm:ss" --scrub-inline-pattern "id=\"[^\"]+\"" --scrub-inline-pattern "data-asset=\"[^\"]+\"" --scrub-inline-remove "temp-session" --verbosity detailed
 ```
 
 When the files match, the tool exits with code 0 and produces no output.

--- a/Verify.Cli.Tests/FileVerifierTests.cs
+++ b/Verify.Cli.Tests/FileVerifierTests.cs
@@ -37,8 +37,26 @@ public class FileVerifierTests
 
         // Pattern includes named groups for prefix and suffix
         // This ensures that the replacement string retains the original quotes around the matched pattern
-        var options = new VerifyFileOptions(ScrubInlinePattern: "(?<prefix>\")/_astro/[^\"]+(?<suffix>\")");
+        var options = new VerifyFileOptions(ScrubInlinePatterns: new[] { "(?<prefix>\")/_astro/[^\"]+(?<suffix>\")" });
         
+        // Act & Assert
+        await FileVerifier.VerifyFileAsync(file, options);
+    }
+
+    [Fact]
+    public async Task FileWithMultipleInlinePatterns_ScrubsAllCorrectly()
+    {
+        // Arrange
+        var file = new FileInfo("examples/azure-pipeline-template-expression.html");
+
+        // Apply two patterns: one for /_astro paths and another for "/astro" paths
+        var options = new VerifyFileOptions(
+            ScrubInlinePatterns: new[]
+            {
+                "(?<prefix>\")/_astro/[^\"]+(?<suffix>\")",
+                "\"/astro/[^\"]+\""
+            });
+
         // Act & Assert
         await FileVerifier.VerifyFileAsync(file, options);
     }
@@ -50,7 +68,7 @@ public class FileVerifierTests
         var file = new FileInfo("examples/withRemovableIds.html");
 
         // Simple text to remove (not regex) - removes all instances
-        var options = new VerifyFileOptions(ScrubInlineRemove: " data-temp-id");
+        var options = new VerifyFileOptions(ScrubInlineRemoves: new[] { " data-temp-id" });
         
         // Act & Assert
         await FileVerifier.VerifyFileAsync(file, options);
@@ -61,7 +79,7 @@ public class FileVerifierTests
     {
         // Arrange
         var file = new FileInfo("examples/same.json");
-        var options = new VerifyFileOptions(ScrubInlineRemove: "");
+        var options = new VerifyFileOptions(ScrubInlineRemoves: new[] { "" });
         
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(async () => await FileVerifier.VerifyFileAsync(file, options));
@@ -72,9 +90,20 @@ public class FileVerifierTests
     {
         // Arrange
         var file = new FileInfo("examples/same.json");
-        var options = new VerifyFileOptions(ScrubInlineRemove: null);
+        var options = new VerifyFileOptions(ScrubInlineRemoves: null);
         
         // Act & Assert - Should not throw
+        await FileVerifier.VerifyFileAsync(file, options);
+    }
+
+    [Fact]
+    public async Task FileWithMultipleInlineRemove_RemovesAllCorrectly()
+    {
+        // Arrange
+        var file = new FileInfo("examples/multiRemove.txt");
+        var options = new VerifyFileOptions(ScrubInlineRemoves: new[] { "REMOVE1", "REMOVE2" });
+
+        // Act & Assert
         await FileVerifier.VerifyFileAsync(file, options);
     }
 

--- a/Verify.Cli.Tests/Verify.Cli.Tests.csproj
+++ b/Verify.Cli.Tests/Verify.Cli.Tests.csproj
@@ -31,4 +31,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="examples\*.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Verify.Cli.Tests/examples/multiRemove.txt
+++ b/Verify.Cli.Tests/examples/multiRemove.txt
@@ -1,0 +1,1 @@
+alpha REMOVE1 beta REMOVE2 gamma

--- a/Verify.Cli.Tests/examples/multiRemove.txt.verified.txt
+++ b/Verify.Cli.Tests/examples/multiRemove.txt.verified.txt
@@ -1,0 +1,1 @@
+alpha  beta  gamma

--- a/Verify.Cli/FileVerifier.cs
+++ b/Verify.Cli/FileVerifier.cs
@@ -12,8 +12,8 @@ public enum Verbosity
 public record VerifyFileOptions(
     DirectoryInfo? VerifiedDir = null,
     string? ScrubInlineDatetime = null,
-    string? ScrubInlinePattern = null,
-    string? ScrubInlineRemove = null,
+    string[]? ScrubInlinePatterns = null,
+    string[]? ScrubInlineRemoves = null,
     Verbosity Verbosity = Verbosity.Normal);
 
 public static class FileVerifier
@@ -33,14 +33,25 @@ public static class FileVerifier
             settings.ScrubInlineDateTimes(options.ScrubInlineDatetime);
         }
 
-        if (options.ScrubInlinePattern != null)
+        if (options.ScrubInlinePatterns != null)
         {
-            settings.AddScrubber(StringScrubber.BuildReplaceStrings(options.ScrubInlinePattern));
+            foreach (var pattern in options.ScrubInlinePatterns)
+            {
+                if (pattern is null)
+                {
+                    continue;
+                }
+                settings.AddScrubber(StringScrubber.BuildReplaceStrings(pattern));
+            }
         }
 
-        if (options.ScrubInlineRemove != null)
+        if (options.ScrubInlineRemoves != null)
         {
-            settings.AddScrubber(StringScrubber.BuildRemoveText(options.ScrubInlineRemove));
+            foreach (var text in options.ScrubInlineRemoves)
+            {
+                // Allow BuildRemoveText to validate empties and throw as per existing behavior
+                settings.AddScrubber(StringScrubber.BuildRemoveText(text));
+            }
         }
 
         VerifierSettings.OmitContentFromException();

--- a/Verify.Cli/Program.cs
+++ b/Verify.Cli/Program.cs
@@ -25,16 +25,16 @@ var scrubInlineDateTime = new Option<string?>(
     Description = "Format for inline date times to scrub, e.g., 'yyyy-MM-ddTHH:mm:ss.fffZ'.",
 };
 
-var scrubInlinePattern = new Option<string?>(
+var scrubInlinePattern = new Option<string[]?>(
     name: "--scrub-inline-pattern")
 {
-    Description = "Regex pattern to match inline strings for scrubbing, e.g., '\"/astro/[^\"]+\"', or '(?<prefix>\")/_astro/[^\"]+(?<suffix>\")'.",
+    Description = "One or more regex patterns to match inline strings for scrubbing. Repeat the option to specify multiple patterns.",
 };
 
-var scrubInlineRemove = new Option<string?>(
+var scrubInlineRemove = new Option<string[]?>(
     name: "--scrub-inline-remove")
 {
-    Description = "Text to match and remove from the file content, e.g., 'temp-id-123'.",
+    Description = "One or more text values to remove from the file content. Repeat the option to specify multiple values (exact match, not regex).",
 };
 
 var verbosityOption = new Option<Verbosity?>(
@@ -62,8 +62,8 @@ rootCommand.SetAction(async (innerParseResult) =>
     var options = new VerifyFileOptions(
         VerifiedDir: innerParseResult.GetValue(verifiedDirOption),
         ScrubInlineDatetime: innerParseResult.GetValue(scrubInlineDateTime),
-        ScrubInlinePattern: innerParseResult.GetValue(scrubInlinePattern),
-        ScrubInlineRemove: innerParseResult.GetValue(scrubInlineRemove),
+        ScrubInlinePatterns: innerParseResult.GetValue(scrubInlinePattern),
+        ScrubInlineRemoves: innerParseResult.GetValue(scrubInlineRemove),
         Verbosity: innerParseResult.GetValue(verbosityOption) ?? Verbosity.Normal
     );
 


### PR DESCRIPTION
Support multiple regex patterns and text values for scrubbing in command line options. Update tests and documentation to reflect these enhancements. Adjust `VerifyFileOptions` to accept arrays for inline scrub patterns and removals.